### PR TITLE
[composer.json] Add explicit psr/log dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "type": "library",
     "require": {
         "php": ">=5.4",
-        "dflydev/dot-access-data": "^1.1.0"
+        "dflydev/dot-access-data": "^1.1.0",
+        "psr/log": "^1.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
This pull request is to add an explicit dependency on `psr/log` because of `Grasmash\Expander\Expander` usage