### PR TITLE
Fixes #9: Use $_SERVER instead of $_ENV for greater reliability.

### DIFF
--- a/src/Expander.php
+++ b/src/Expander.php
@@ -276,8 +276,8 @@ class Expander implements LoggerAwareInterface
         if (strpos($property_name, "env.") === 0 &&
           !$data->has($property_name)) {
             $env_key = substr($property_name, 4);
-            if (isset($_ENV[$env_key])) {
-              $data->set($property_name, $_ENV[$env_key]);
+            if (isset($_SERVER[$env_key])) {
+              $data->set($property_name, $_SERVER[$env_key]);
             }
         }
 

--- a/src/Expander.php
+++ b/src/Expander.php
@@ -112,8 +112,8 @@ class Expander implements LoggerAwareInterface
             // Recursive case.
             if (is_array($value)) {
                 $this->doExpandArrayProperties($data, $value, $parent_keys . "$key.", $reference_data);
-            } // Base case.
-            else {
+            } else {
+                // Base case.
                 $this->expandStringProperties($data, $parent_keys, $reference_data, $value, $key);
             }
         }
@@ -208,8 +208,8 @@ class Expander implements LoggerAwareInterface
         // Use only values within the subject array's data.
         if (!$reference_data) {
             return $this->expandProperty($property_name, $unexpanded_value, $data);
-        } // Search both the subject array's data and the reference data for a value.
-        else {
+        } else {
+            // Search both the subject array's data and the reference data for a value.
             return $this->expandPropertyWithReferenceData(
                 $property_name,
                 $unexpanded_value,
@@ -277,7 +277,7 @@ class Expander implements LoggerAwareInterface
           !$data->has($property_name)) {
             $env_key = substr($property_name, 4);
             if (isset($_SERVER[$env_key])) {
-              $data->set($property_name, $_SERVER[$env_key]);
+                $data->set($property_name, $_SERVER[$env_key]);
             }
         }
 

--- a/tests/phpunit/ExpanderTest.php
+++ b/tests/phpunit/ExpanderTest.php
@@ -132,6 +132,5 @@ class ExpanderTest extends TestCase
     {
         putenv("$key=$value");
         $_SERVER[$key] = $value;
-
     }
 }

--- a/tests/phpunit/ExpanderTest.php
+++ b/tests/phpunit/ExpanderTest.php
@@ -22,7 +22,8 @@ class ExpanderTest extends TestCase
     {
         $expander = new Expander();
 
-        putenv("test=gomjabbar");
+        $this->setEnvVarFixture('test', 'gomjabbar');
+
         $expanded = $expander->expandArrayProperties($array);
         $this->assertEquals('gomjabbar', $expanded['env-test']);
         $this->assertEquals('Frank Herbert 1965', $expanded['book']['copyright']);
@@ -125,5 +126,12 @@ class ExpanderTest extends TestCase
             [ ['author' => 'Frank Herbert'], 'author', '${author}', 'Frank Herbert' ],
             [ ['book' =>  ['author' => 'Frank Herbert' ]], 'book.author', '${book.author}', 'Frank Herbert' ],
         ];
+    }
+
+    protected function setEnvVarFixture($key, $value)
+    {
+        putenv("$key=$value");
+        $_SERVER[$key] = $value;
+
     }
 }


### PR DESCRIPTION
`$_ENV` cannot be relied on, as it is only populated if the php.ini setting variables_order contains "E". This configuration option is often missing in default php configurations.

This PR switches to `$_SERVER`, which is more reliable.