### PR TITLE
PHP 8.1 deprecation notice by passing null to strpos()

### DIFF
--- a/src/Expander.php
+++ b/src/Expander.php
@@ -147,7 +147,7 @@ class Expander implements LoggerAwareInterface
         $pattern = '/\$\{([^\$}]+)\}/';
         // We loop through all placeholders in a given string.
         // E.g., '${placeholder1} ${placeholder2}' requires two replacements.
-        while (strpos($value, '${') !== false) {
+        while (strpos((string)$value, '${') !== false) {
             $original_value = $value;
             $value = preg_replace_callback(
                 $pattern,

--- a/tests/phpunit/ExpanderTest.php
+++ b/tests/phpunit/ExpanderTest.php
@@ -93,10 +93,12 @@ class ExpanderTest extends TestCase
               ],
               'expand-array' => '${inline-array}',
               'env-test' => '${env.test}',
+              'test_expanded_to_null' => '${book.expanded_to_null}'
             ],
             [
               'book' => [
-                'sequel' => 'Dune Messiah'
+                'sequel' => 'Dune Messiah',
+                'expanded_to_null' => null,
               ]
             ]
           ],


### PR DESCRIPTION
Fixes #14 

When a token, say `${foo.bar}`, resolves to `null`, is passed again to...

```php
        // We loop through all placeholders in a given string.
        // E.g., '${placeholder1} ${placeholder2}' requires two replacements.
        while (strpos($value, '${') !== false) {
```
as last check before exiting `while (...) {...}`, but passing `null` to `strpos()`, instead of string, is deprecated in PHP 8.1