### PR TITLE
Allow psr/log ^3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
     "description": "Expands internal property references in PHP arrays file.",
     "type": "library",
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.1",
         "dflydev/dot-access-data": "^3.0.0",
-        "psr/log": "^1 | ^2"
+        "psr/log": "^1 | ^2 | ^3"
     },
     "license": "MIT",
     "authors": [
@@ -21,7 +21,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0 || ^8.0 || ^9",
-        "php-coveralls/php-coveralls": "^2.0",
         "greg-1-anderson/composer-test-scenarios": "^1",
         "squizlabs/php_codesniffer": "^2.7 || ^3.3"
     },

--- a/src/Expander.php
+++ b/src/Expander.php
@@ -54,7 +54,7 @@ class Expander implements LoggerAwareInterface
     /**
      * @param \Psr\Log\LoggerInterface $logger
      */
-    public function setLogger(\Psr\Log\LoggerInterface $logger)
+    public function setLogger(\Psr\Log\LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }


### PR DESCRIPTION
Drupal 10 will likely require psr/log v3 - https://www.drupal.org/project/drupal/issues/3272447. I'm trying to prep the ground so that this will not break Drush. This library is a dependency of Drush and limits which psr/log can be used.

See also:
* https://github.com/consolidation/log/pull/27
* https://github.com/consolidation/annotated-command/pull/266

Unfortunately one of the dev dependencies is not compatible - php-coveralls/php-coveralls so I've removed it.