### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/src/Expander.php
+++ b/src/Expander.php
@@ -103,7 +103,7 @@ class Expander implements LoggerAwareInterface
         Data   $data,
         array  $array,
         string $parent_keys = '',
-        Data $reference_data = null
+        ?Data $reference_data = null
     ) {
         foreach ($array as $key => $value) {
             // Boundary condition(s).
@@ -201,7 +201,7 @@ class Expander implements LoggerAwareInterface
     public function expandStringPropertiesCallback(
         array $matches,
         Data  $data,
-        Data $reference_data = null
+        ?Data $reference_data = null
     ): mixed {
         $property_name = $matches[1];
         $unexpanded_value = $matches[0];


### PR DESCRIPTION
RFC https://php.watch/rfcs/deprecate-implicitly-nullable-types

Testing via docker
```
expander$ docker run --rm -v $(pwd):/mnt -w /mnt php:8.4.0alpha2-cli-alpine find . -type f -name '*.php' -exec php -l {} \;
No syntax errors detected in ./tests/src/ExpanderTest.php
No syntax errors detected in ./src/StringifierInterface.php

Deprecated: Grasmash\Expander\Expander::doExpandArrayProperties(): Implicitly marking parameter $reference_data as nullable is deprecated, the explicit nullable type must be used instead in ./src/Expander.php on line 102

Deprecated: Grasmash\Expander\Expander::expandStringPropertiesCallback(): Implicitly marking parameter $reference_data as nullable is deprecated, the explicit nullable type must be used instead in ./src/Expander.php on line 201
No syntax errors detected in ./src/Expander.php
No syntax errors detected in ./src/Stringifier.php
```
