### PR TITLE
Modernize library for 4.x: security fixes, strict types, tooling updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.{yml,yaml,json}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "*.x" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "*.x" ]
 
 permissions:
   contents: read
@@ -25,9 +25,12 @@ jobs:
           - os: "ubuntu-latest"
             php: "8.4"
             coverage: "pcov"
+          - os: "ubuntu-latest"
+            php: "8.5"
+            coverage: "none"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: shivammathur/setup-php@v2
         with:
@@ -40,6 +43,9 @@ jobs:
 
       - name: Install dependencies
         run: composer -n update --prefer-dist -o
+
+      - name: Security audit
+        run: composer audit
 
       - name: Run test suite
         if: matrix.coverage == 'none'

--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,9 @@
 */Entity/*~
 
 .idea
-.phpunit.result.cachecomposer.lock
+.phpunit.result.cache
+.phpunit.cache/
+composer.lock
+.DS_Store
+
+build/.phpcs-cache

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ $array = [
 $expander = new Expander();
 // Optionally set a logger.
 $expander->setLogger(new Psr\Log\NullLogger());
-// Optionally set a Stringfier, used to convert array placeholders into strings. Defaults to using implode() with `,` delimeter.
+// Optionally set a Stringifier, used to convert array placeholders into strings. Defaults to using implode() with `,` delimiter.
 // @see StringifierInterface.
 $expander->setStringifier(new Grasmash\Expander\Stringifier());
 
@@ -74,13 +74,13 @@ $expander->setStringifier(new Grasmash\Expander\Stringifier());
 $expanded = $expander->expandArrayProperties($array);
 
 // Parse an array, expanding references using both internal and supplementary values.
-$reference_properties =  'book' => ['sequel' => 'Dune Messiah'];
+$reference_properties = ['book' => ['sequel' => 'Dune Messiah']];
 // Set an environmental variable.
 putenv("test=gomjabbar");
 $expanded = $expander->expandArrayProperties($array, $reference_properties);
 
 print_r($expanded);
-````
+```
 
 Resultant array:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,10 +2,29 @@
 
 ### Execute tests
 
-    ./scripts/run-tests.sh
+    composer test
+
+This runs linting (`composer lint`), unit tests (`composer unit`), coding
+standards checks (`composer cs`), and static analysis (`composer stan`).
 
 To quickly fix PHPCS issues:
 
-    ./scripts/clean-code.sh
-    
+    composer cbf
 
+## 4.0 upgrade notes
+
+- PHP 8.2+ is required.
+- All source files now declare `strict_types=1`.
+- `StringifierInterface::stringifyArray()` is now an instance method rather
+  than a static method. Custom `StringifierInterface` implementations and any
+  callers of `Stringifier::stringifyArray()` as a static method must update.
+- `Expander::expandArrayProperties()` now requires `$reference_array` to be an
+  array.
+- `Expander::expandPropertyWithReferenceData()` returns `mixed` instead of
+  `?string`, so non-string values (booleans, integers, floats) retain their
+  types when expanded via reference data.
+- `${env.*}` placeholders no longer read `HTTP_*` keys from `$_SERVER`, since
+  those originate from client-supplied request headers in a web context.
+- Environment variables with falsy values (e.g. `0`) now expand correctly.
+- Expansion of a single string is capped at 25 passes and 1 MiB to prevent
+  runaway growth from circular references with surrounding text.

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,24 @@
 {
     "name": "grasmash/expander",
-    "description": "Expands internal property references in PHP arrays file.",
+    "description": "Expands internal property references in PHP arrays.",
     "type": "library",
+    "keywords": [
+        "array",
+        "configuration",
+        "dot-notation",
+        "expansion",
+        "placeholder",
+        "yaml"
+    ],
+    "homepage": "https://github.com/grasmash/expander",
+    "support": {
+        "issues": "https://github.com/grasmash/expander/issues",
+        "source": "https://github.com/grasmash/expander"
+    },
     "require": {
         "php": ">=8.2",
         "dflydev/dot-access-data": "^3.0.0",
-        "psr/log": "^2 | ^3"
+        "psr/log": "^2 || ^3"
     },
     "license": "MIT",
     "authors": [
@@ -25,14 +38,15 @@
         }
     },
     "require-dev": {
-        "greg-1-anderson/composer-test-scenarios": "^1",
-        "php-coveralls/php-coveralls": "^2.5",
-        "phpunit/phpunit": "^9",
-        "squizlabs/php_codesniffer": "^3.3"
+        "php-coveralls/php-coveralls": "^2.8",
+        "phpstan/phpstan": "^2.0",
+        "phpunit/phpunit": "^10.5 || ^11 || ^12 || ^13",
+        "squizlabs/php_codesniffer": "^3.13"
     },
     "scripts": {
         "cs": "phpcs",
         "cbf": "phpcbf",
+        "stan": "phpstan",
         "unit": "phpunit",
         "lint": [
             "find src -name '*.php' -print0 | xargs -0 -n1 php -l",
@@ -41,7 +55,8 @@
         "test": [
             "@lint",
             "@unit",
-            "@cs"
+            "@cs",
+            "@stan"
         ],
         "coverage": "php -d pcov.enabled=1 vendor/bin/phpunit tests/src --coverage-clover build/logs/clover.xml",
         "coveralls": [
@@ -51,10 +66,5 @@
     "config": {
         "optimize-autoloader": true,
         "sort-packages": true
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "4.x-dev"
-        }
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,5 @@
+parameters:
+    level: 5
+    paths:
+        - src
+        - tests/src

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,14 @@
 <?xml version="1.0"?>
 <!-- phpunit.xml.dist -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">src</directory>
-    </include>
-    <report>
-      <clover outputFile="build/logs/clover.xml"/>
-    </report>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.2/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <testsuites>
-    <testsuite name="Yaml Expander Test Suite">
+    <testsuite name="Expander Test Suite">
       <directory>tests/src</directory>
     </testsuite>
   </testsuites>
-  <logging/>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Expander.php
+++ b/src/Expander.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Grasmash\Expander;
 
 use Dflydev\DotAccessData\Data;
@@ -8,18 +10,25 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 /**
- * Class Expander
- * @package Grasmash\Expander
+ * Expands property placeholders in arrays.
  */
 class Expander implements LoggerAwareInterface
 {
     /**
-     * @var \Grasmash\Expander\StringifierInterface
+     * Maximum passes over a single string value during expansion. Guards
+     * against unbounded growth from mutually recursive placeholders, e.g.
+     * ['a' => 'x${b}', 'b' => 'y${a}'].
      */
-    protected StringifierInterface $stringifier;
+    protected const MAX_ITERATIONS = 25;
+
     /**
-     * @var \Psr\Log\LoggerInterface
+     * Maximum length of an expanded string value. Circular references with
+     * surrounding text double the value length on every pass; this caps that
+     * growth before it exhausts memory.
      */
+    protected const MAX_LENGTH = 1048576;
+
+    protected StringifierInterface $stringifier;
     protected LoggerInterface $logger;
 
     public function __construct()
@@ -28,33 +37,21 @@ class Expander implements LoggerAwareInterface
         $this->setStringifier(new Stringifier());
     }
 
-    /**
-     * @return \Grasmash\Expander\StringifierInterface
-     */
     public function getStringifier(): StringifierInterface
     {
         return $this->stringifier;
     }
 
-    /**
-     * @param \Grasmash\Expander\StringifierInterface $stringifier
-     */
-    public function setStringifier(StringifierInterface $stringifier)
+    public function setStringifier(StringifierInterface $stringifier): void
     {
         $this->stringifier = $stringifier;
     }
 
-    /**
-     * @return \Psr\Log\LoggerInterface
-     */
     public function getLogger(): LoggerInterface
     {
         return $this->logger;
     }
 
-    /**
-     * @param \Psr\Log\LoggerInterface $logger
-     */
     public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
@@ -67,12 +64,14 @@ class Expander implements LoggerAwareInterface
      *
      * @param array $array
      *   An array containing properties to expand.
+     * @param array $reference_array
+     *   An optional array of supplemental values used for property expansion.
      *
      * @return array
      *   The modified array in which placeholders have been replaced with
      *   values.
      */
-    public function expandArrayProperties(array $array, $reference_array = []): array
+    public function expandArrayProperties(array $array, array $reference_array = []): array
     {
         $data = new Data($array);
         if ($reference_array) {
@@ -104,7 +103,7 @@ class Expander implements LoggerAwareInterface
         array  $array,
         string $parent_keys = '',
         ?Data $reference_data = null
-    ) {
+    ): void {
         foreach ($array as $key => $value) {
             // Boundary condition(s).
             if ($value === null || is_bool($value)) {
@@ -115,7 +114,7 @@ class Expander implements LoggerAwareInterface
                 $this->doExpandArrayProperties($data, $value, $parent_keys . "$key.", $reference_data);
             } else {
                 // Base case.
-                $this->expandStringProperties($data, $parent_keys, $reference_data, $value, $key);
+                $this->expandStringProperties($data, $parent_keys, $reference_data, (string) $value, (string) $key);
             }
         }
     }
@@ -135,8 +134,6 @@ class Expander implements LoggerAwareInterface
      *   The unexpanded property value.
      * @param string $key
      *   The immediate key of the property.
-     *
-     * @return mixed
      */
     protected function expandStringProperties(
         Data   $data,
@@ -146,25 +143,31 @@ class Expander implements LoggerAwareInterface
         string $key
     ): mixed {
         $pattern = '/\$\{([^\$}]+)\}/';
+        $iterations = 0;
         // We loop through all placeholders in a given string.
         // E.g., '${placeholder1} ${placeholder2}' requires two replacements.
-        while (str_contains((string) $value, '${')) {
+        while (is_string($value) && str_contains($value, '${')) {
+            if (++$iterations > static::MAX_ITERATIONS || strlen($value) > static::MAX_LENGTH) {
+                $this->log("Aborting expansion of $key. Value may contain circular references.");
+                break;
+            }
             $original_value = $value;
-            $value = preg_replace_callback(
-                $pattern,
-                function ($matches) use ($data, $reference_data) {
-                    return $this->expandStringPropertiesCallback($matches, $data, $reference_data);
-                },
-                $value,
-                -1,
-                $count
-            );
-
-            // If the value was just a _single_ property reference, we have the opportunity to preserve the data type.
-            if ($count === 1) {
-                preg_match($pattern, $original_value, $matches);
-                if ($matches[0] === $original_value) {
-                    $value = $this->expandStringPropertiesCallback($matches, $data, $reference_data);
+            // If the value is a _single_ property reference, expand it
+            // directly so that the replacement's data type is preserved.
+            if (preg_match($pattern, $value, $matches) && $matches[0] === $value) {
+                $value = $this->expandStringPropertiesCallback($matches, $data, $reference_data);
+            } else {
+                $value = $this->replacePlaceholders(
+                    $pattern,
+                    function ($matches) use ($data, $reference_data) {
+                        return (string) $this->expandStringPropertiesCallback($matches, $data, $reference_data);
+                    },
+                    $value
+                );
+                // A null value indicates a PCRE error.
+                if ($value === null) {
+                    $this->log("Aborting expansion of $key: " . preg_last_error_msg());
+                    return $original_value;
                 }
             }
 
@@ -186,6 +189,16 @@ class Expander implements LoggerAwareInterface
     }
 
     /**
+     * Replaces all placeholders in a string.
+     *
+     * Returns null on a PCRE error, per preg_replace_callback().
+     */
+    protected function replacePlaceholders(string $pattern, callable $callback, string $subject): ?string
+    {
+        return preg_replace_callback($pattern, $callback, $subject);
+    }
+
+    /**
      * Expansion callback used by preg_replace_callback() in expandProperty().
      *
      * @param array $matches
@@ -195,8 +208,6 @@ class Expander implements LoggerAwareInterface
      * @param Data|null $reference_data
      *   A reference data object. This is not operated upon but is used as a
      *   reference to provide supplemental values for property expansion.
-     *
-     * @return mixed
      */
     public function expandStringPropertiesCallback(
         array $matches,
@@ -220,28 +231,25 @@ class Expander implements LoggerAwareInterface
         }
     }
 
-  /**
-   * Searches both the subject data and the reference data for value.
-   *
-   * @param string $property_name
-   *   The name of the value for which to search.
-   * @param string $unexpanded_value
-   *   The original, unexpanded value, containing the placeholder.
-   * @param Data $data
-   *   A data object containing the complete array being operated upon.
-   * @param Data|null $reference_data
-   *   A reference data object. This is not operated upon but is used as a
-   *   reference to provide supplemental values for property expansion.
-   *
-   * @return string|null The expanded string.
-   *   The expanded string.
-   */
+    /**
+     * Searches both the subject data and the reference data for value.
+     *
+     * @param string $property_name
+     *   The name of the value for which to search.
+     * @param string $unexpanded_value
+     *   The original, unexpanded value, containing the placeholder.
+     * @param Data $data
+     *   A data object containing the complete array being operated upon.
+     * @param Data|null $reference_data
+     *   A reference data object. This is not operated upon but is used as a
+     *   reference to provide supplemental values for property expansion.
+     */
     public function expandPropertyWithReferenceData(
         string $property_name,
         string $unexpanded_value,
         Data   $data,
         ?Data $reference_data
-    ): ?string {
+    ): mixed {
         $expanded_value = $this->expandProperty(
             $property_name,
             $unexpanded_value,
@@ -249,7 +257,7 @@ class Expander implements LoggerAwareInterface
         );
         // If the string was not changed using the subject data, try using
         // the reference data.
-        if ($expanded_value === $unexpanded_value) {
+        if ($expanded_value === $unexpanded_value && $reference_data !== null) {
             $expanded_value = $this->expandProperty(
                 $property_name,
                 $unexpanded_value,
@@ -269,18 +277,18 @@ class Expander implements LoggerAwareInterface
      *   The original, unexpanded value, containing the placeholder.
      * @param Data $data
      *   A data object containing possible replacement values.
-     *
-     * @return mixed
      */
     public function expandProperty(string $property_name, string $unexpanded_value, Data $data): mixed
     {
         if (str_starts_with($property_name, "env.") &&
           !$data->has($property_name)) {
             $env_key = substr($property_name, 4);
-            if (isset($_SERVER[$env_key])) {
+            // Skip HTTP_* keys in $_SERVER: in a web context these come from
+            // client-supplied request headers, not the environment.
+            if (isset($_SERVER[$env_key]) && !str_starts_with($env_key, 'HTTP_')) {
                 $data->set($property_name, $_SERVER[$env_key]);
-            } elseif (getenv($env_key)) {
-                $data->set($property_name, getenv($env_key));
+            } elseif (($env_value = getenv($env_key)) !== false) {
+                $data->set($property_name, $env_value);
             }
         }
 
@@ -292,7 +300,7 @@ class Expander implements LoggerAwareInterface
             if (is_array($expanded_value)) {
                 return $this->getStringifier()->stringifyArray($expanded_value);
             }
-            $this->log("Expanding property \${'$property_name'} => $expanded_value.");
+            $this->log("Expanding property \${'$property_name'} => " . var_export($expanded_value, true) . ".");
             return $expanded_value;
         }
     }
@@ -303,8 +311,8 @@ class Expander implements LoggerAwareInterface
      * @param string $message
      *   The message to log.
      */
-    public function log(string $message)
+    public function log(string $message): void
     {
-        $this->getLogger()?->debug($message);
+        $this->getLogger()->debug($message);
     }
 }

--- a/src/Stringifier.php
+++ b/src/Stringifier.php
@@ -1,15 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Grasmash\Expander;
 
 /**
- * Class Stringifier
- * @package Grasmash\Expander
+ * Converts arrays to strings during property expansion.
  */
 class Stringifier implements StringifierInterface
 {
     /**
-     * Converts array to string.
+     * Converts an array to a comma-delimited string.
      *
      * @param array $array
      *   The array to convert.
@@ -17,7 +18,7 @@ class Stringifier implements StringifierInterface
      * @return string
      *   The resultant string.
      */
-    public static function stringifyArray(array $array): string
+    public function stringifyArray(array $array): string
     {
         return implode(',', $array);
     }

--- a/src/StringifierInterface.php
+++ b/src/StringifierInterface.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Grasmash\Expander;
 
 interface StringifierInterface
 {
     /**
-     * Converts array to string.
+     * Converts an array to a string.
      *
      * @param array $array
      *   The array to convert.
@@ -13,5 +15,5 @@ interface StringifierInterface
      * @return string
      *   The resultant string.
      */
-    public static function stringifyArray(array $array): string;
+    public function stringifyArray(array $array): string;
 }

--- a/tests/src/ExpanderTest.php
+++ b/tests/src/ExpanderTest.php
@@ -1,24 +1,41 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Grasmash\Expander\Tests;
 
 use Dflydev\DotAccessData\Data;
 use Grasmash\Expander\Expander;
 use Grasmash\Expander\Stringifier;
+use Grasmash\Expander\StringifierInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class ExpanderTest extends TestCase
 {
+    /**
+     * Environment variable keys set during a test, cleaned up in tearDown().
+     *
+     * @var string[]
+     */
+    private array $envVarFixtures = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->envVarFixtures as $key) {
+            putenv($key);
+            unset($_SERVER[$key]);
+        }
+        $this->envVarFixtures = [];
+        parent::tearDown();
+    }
 
     /**
      * Tests Expander::expandArrayProperties().
-     *
-     * @param array $array
-     * @param array $reference_array
-     *
-     * @dataProvider providerSourceData
      */
-    public function testExpandArrayProperties(array $array, array $reference_array)
+    #[DataProvider('providerSourceData')]
+    public function testExpandArrayProperties(array $array, array $reference_array): void
     {
         $expander = new Expander();
 
@@ -31,23 +48,33 @@ class ExpanderTest extends TestCase
         $this->assertEquals('Dune by Frank Herbert', $expanded['summary']);
         $this->assertEquals('${book.media.1}, hardcover', $expanded['available-products']);
         $this->assertEquals('Dune', $expanded['product-name']);
-        $this->assertEquals(Stringifier::stringifyArray($array['inline-array']), $expanded['expand-array']);
+        $this->assertEquals('one,two,three', $expanded['expand-array']);
+        $this->assertEquals('${not.real.property}', $expanded['publisher']);
+        $this->assertEquals('${book.expanded_to_null}', $expanded['test_expanded_to_null']);
 
-        $this->assertEquals(true, $expanded['boolean-value']);
+        $this->assertTrue($expanded['boolean-value']);
         $this->assertIsBool($expanded['boolean-value']);
-        $this->assertEquals(true, $expanded['expand-boolean']);
+        $this->assertTrue($expanded['expand-boolean']);
         $this->assertIsBool($expanded['expand-boolean']);
+
+        $this->assertSame(5, $expanded['expand-int']);
+        $this->assertSame(99.99, $expanded['expand-float']);
 
         $expanded = $expander->expandArrayProperties($array, $reference_array);
         $this->assertEquals('Dune Messiah, and others.', $expanded['sequels']);
         $this->assertEquals('Dune Messiah', $expanded['book']['nested-reference']);
+        $this->assertNull($expanded['test_expanded_to_null']);
+        // Types must be preserved in reference-data mode too.
+        $this->assertTrue($expanded['expand-boolean']);
+        $this->assertSame(5, $expanded['expand-int']);
+        $this->assertSame(99.99, $expanded['expand-float']);
     }
 
     /**
      * @return array
      *   An array of values to test.
      */
-    public function providerSourceData(): array
+    public static function providerSourceData(): array
     {
         return [
           [
@@ -85,6 +112,10 @@ class ExpanderTest extends TestCase
               'product-name' => '${${type}.title}',
               'boolean-value' => true,
               'expand-boolean' => '${boolean-value}',
+              'int-value' => 5,
+              'expand-int' => '${int-value}',
+              'float-value' => 99.99,
+              'expand-float' => '${float-value}',
               'null-value' => null,
               'inline-array' => [
                 0 => 'one',
@@ -107,10 +138,9 @@ class ExpanderTest extends TestCase
 
     /**
      * Tests Expander::expandProperty().
-     *
-     * @dataProvider providerTestExpandProperty
      */
-    public function testExpandProperty(array $array, $property_name, $unexpanded_string, $expected)
+    #[DataProvider('providerTestExpandProperty')]
+    public function testExpandProperty(array $array, string $property_name, string $unexpanded_string, mixed $expected): void
     {
         $data = new Data($array);
         $expander = new Expander();
@@ -122,7 +152,7 @@ class ExpanderTest extends TestCase
     /**
      * @return array
      */
-    public function providerTestExpandProperty(): array
+    public static function providerTestExpandProperty(): array
     {
         return [
             [ ['author' => 'Frank Herbert'], 'author', '${author}', 'Frank Herbert' ],
@@ -130,13 +160,139 @@ class ExpanderTest extends TestCase
         ];
     }
 
-  /**
-   * @param $key
-   * @param $value
-   */
-    protected function setEnvVarFixture($key, $value)
+    /**
+     * Tests the getenv() fallback when the variable is absent from $_SERVER.
+     */
+    public function testExpandEnvPropertyGetenvFallback(): void
+    {
+        putenv('getenv_only=fallback_value');
+        $this->envVarFixtures[] = 'getenv_only';
+        $this->assertArrayNotHasKey('getenv_only', $_SERVER);
+
+        $expander = new Expander();
+        $expanded = $expander->expandArrayProperties(['env-fallback' => '${env.getenv_only}']);
+        $this->assertEquals('fallback_value', $expanded['env-fallback']);
+    }
+
+    /**
+     * Tests that falsy (but set) environment variables like "0" expand.
+     */
+    public function testExpandEnvPropertyFalsyValue(): void
+    {
+        putenv('falsy_env=0');
+        $this->envVarFixtures[] = 'falsy_env';
+        $this->assertArrayNotHasKey('falsy_env', $_SERVER);
+
+        $expander = new Expander();
+        $expanded = $expander->expandArrayProperties(['timeout' => '${env.falsy_env}']);
+        $this->assertEquals('0', $expanded['timeout']);
+    }
+
+    /**
+     * Tests that HTTP_* keys in $_SERVER (client-controlled request headers)
+     * are never used for ${env.*} expansion.
+     */
+    public function testExpandEnvPropertyIgnoresHttpHeaders(): void
+    {
+        $_SERVER['HTTP_X_INJECTED'] = 'attacker-value';
+        $this->envVarFixtures[] = 'HTTP_X_INJECTED';
+
+        $expander = new Expander();
+        $expanded = $expander->expandArrayProperties(['header' => '${env.HTTP_X_INJECTED}']);
+        $this->assertEquals('${env.HTTP_X_INJECTED}', $expanded['header']);
+    }
+
+    /**
+     * Tests that circular references terminate rather than looping forever.
+     */
+    public function testCircularReferencesTerminate(): void
+    {
+        $expander = new Expander();
+
+        $expanded = $expander->expandArrayProperties(['a' => '${a}']);
+        $this->assertEquals('${a}', $expanded['a']);
+
+        $expanded = $expander->expandArrayProperties(['a' => '${b}', 'b' => '${a}']);
+        $this->assertEquals('${a}', $expanded['a']);
+        $this->assertEquals('${a}', $expanded['b']);
+
+        $expanded = $expander->expandArrayProperties(['a' => '${b}', 'b' => '${c}', 'c' => '${a}']);
+        $this->assertEquals('${a}', $expanded['a']);
+        $this->assertEquals('${a}', $expanded['b']);
+        $this->assertEquals('${a}', $expanded['c']);
+    }
+
+    /**
+     * Tests that mutually recursive placeholders with surrounding text do not
+     * grow unboundedly (previously caused memory exhaustion).
+     */
+    public function testCircularReferencesWithTextTerminate(): void
+    {
+        $expander = new Expander();
+        $expanded = $expander->expandArrayProperties(['a' => 'x${b}', 'b' => 'y${a}']);
+        $this->assertIsString($expanded['a']);
+        $this->assertIsString($expanded['b']);
+    }
+
+    /**
+     * Tests that a PCRE failure during replacement aborts expansion and
+     * preserves the original value.
+     */
+    public function testPcreErrorAbortsExpansion(): void
+    {
+        $expander = new class extends Expander {
+            protected function replacePlaceholders(string $pattern, callable $callback, string $subject): ?string
+            {
+                return null;
+            }
+        };
+        $logger = $this->createMock(LoggerInterface::class);
+        $expander->setLogger($logger);
+        $logger->expects($this->once())
+            ->method('debug')
+            ->with($this->stringContains('Aborting expansion of a'));
+
+        $expanded = $expander->expandArrayProperties(['a' => 'text ${b} more', 'b' => 'val']);
+        $this->assertSame('text ${b} more', $expanded['a']);
+    }
+
+    /**
+     * Tests logger and stringifier accessors and their use during expansion.
+     */
+    public function testSettersAndGetters(): void
+    {
+        $expander = new Expander();
+        $logger = $this->createMock(LoggerInterface::class);
+        $stringifier = $this->createMock(StringifierInterface::class);
+
+        $expander->setLogger($logger);
+        $expander->setStringifier($stringifier);
+        $this->assertSame($logger, $expander->getLogger());
+        $this->assertSame($stringifier, $expander->getStringifier());
+
+        $logger->expects($this->atLeastOnce())
+            ->method('debug')
+            ->with($this->stringContains('not.real.property'));
+        $stringifier->expects($this->once())
+            ->method('stringifyArray')
+            ->with(['one', 'two'])
+            ->willReturn('one, two');
+
+        $expanded = $expander->expandArrayProperties([
+            'missing' => '${not.real.property}',
+            'list' => ['one', 'two'],
+            'joined' => '${list}',
+        ]);
+        $this->assertSame('one, two', $expanded['joined']);
+    }
+
+    /**
+     * Sets an environment variable fixture, registered for tearDown cleanup.
+     */
+    protected function setEnvVarFixture(string $key, string $value): void
     {
         putenv("$key=$value");
         $_SERVER[$key] = $value;
+        $this->envVarFixtures[] = $key;
     }
 }

--- a/tests/src/StringifierTest.php
+++ b/tests/src/StringifierTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Grasmash\Expander\Tests;
+
+use Grasmash\Expander\Stringifier;
+use Grasmash\Expander\StringifierInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class StringifierTest extends TestCase
+{
+    public function testImplementsInterface(): void
+    {
+        $this->assertInstanceOf(StringifierInterface::class, new Stringifier());
+    }
+
+    #[DataProvider('providerStringifyArray')]
+    public function testStringifyArray(array $array, string $expected): void
+    {
+        $this->assertSame($expected, (new Stringifier())->stringifyArray($array));
+    }
+
+    /**
+     * @return array
+     */
+    public static function providerStringifyArray(): array
+    {
+        return [
+            'empty array' => [[], ''],
+            'single element' => [['one'], 'one'],
+            'multiple elements' => [['one', 'two', 'three'], 'one,two,three'],
+            'non-sequential keys' => [[5 => 'a', 9 => 'b'], 'a,b'],
+            'mixed scalar types' => [[1, true, null, 'x'], '1,1,,x'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Multi-dimension review and modernization of the library for the 4.x major version. 55 candidate findings were adversarially verified; the 35 confirmed ones are fixed here, each behavior change developed test-first.

### Bug and security fixes (each with a regression test)
- **Memory-exhaustion DoS**: circular references with surrounding text (`['a' => 'x${b}', 'b' => 'y${a}']`) doubled the value length every pass until the process crashed. Expansion is now capped at 25 passes / 1 MiB.
- **`${env.*}` no longer reads `HTTP_*` keys from `$_SERVER`** — in a web context those come from client-supplied request headers (Symfony precedent).
- **Falsy env vars expand**: `VAR=0` previously failed a truthiness check on `getenv()`.
- **Type preservation in reference mode**: `expandPropertyWithReferenceData()` declared `?string`, silently coercing booleans to `"1"` and numerics to strings. Now returns `mixed`.
- **Single-placeholder strings expanded twice**, duplicating logger/stringifier side effects. Now expanded once.
- **PCRE error guard**: a `preg_replace_callback()` failure now restores the original value instead of nulling it.

### Modernization (BC breaks documented in RELEASE.md)
- `declare(strict_types=1)` and full parameter/return types everywhere.
- `StringifierInterface::stringifyArray()` is now an instance method.
- `expandArrayProperties()` requires `array $reference_array`.

### Tooling and CI
- PHPUnit `^9` → `^10.5 || ^11 || ^12 || ^13`; config migrated (the old config silently ran **zero tests** under PHPUnit 13), tests converted to attributes with static providers, env-var fixtures cleaned up in `tearDown()`.
- phpstan level 5 added to `composer test`.
- Dropped abandoned `greg-1-anderson/composer-test-scenarios`.
- CI now triggers on `main` and `*.x` (pushes to `4.x` previously never ran CI), adds PHP 8.5 to the matrix, a `composer audit` step, `checkout@v6`, and Dependabot for composer + GitHub Actions.
- **100% line/method/class coverage** (16 tests, 52 assertions, was 3/15).
- Fixed README example syntax error, malformed `.gitignore` last line, stale `RELEASE.md` script references; added `.editorconfig` and composer metadata.

## Test plan
- [x] `composer test` (lint + PHPUnit + phpcs + phpstan) passes locally on PHP 8.4
- [x] Coverage at 100% lines/methods/classes via pcov (same driver as CI)
- [x] README example verified end-to-end
- [ ] CI matrix (PHP 8.2/8.3/8.4/8.5) green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)