### PR TITLE
Allow PHP_CodeSniffer 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "php-coveralls/php-coveralls": "^2.8",
         "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^10.5 || ^11 || ^12 || ^13",
-        "squizlabs/php_codesniffer": "^3.13"
+        "squizlabs/php_codesniffer": "^3.13 || ^4.0"
     },
     "scripts": {
         "cs": "phpcs",


### PR DESCRIPTION
## Summary

Widens the `squizlabs/php_codesniffer` dev constraint from `^3.13` to `^3.13 || ^4.0`, allowing the current 4.0.1 major release. The existing `phpcs.xml.dist` ruleset (PSR2) works unchanged.

## Test plan

- [x] `composer test` (lint + PHPUnit + phpcs 4.0.1 + phpstan) passes locally on PHP 8.4 — 16 tests, 52 assertions
- [ ] CI matrix (PHP 8.2/8.3/8.4/8.5) green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)